### PR TITLE
FIX Scene Change Spawn Error

### DIFF
--- a/Client/Assets/Scripts/Managers/Contents/ObjectManager.cs
+++ b/Client/Assets/Scripts/Managers/Contents/ObjectManager.cs
@@ -9,7 +9,7 @@ public class ObjectManager
 {
 	public MyPlayerController MyPlayer { get; set; }
 	public UserControllerScript OtherPlayer { get; set; }
-	Dictionary<int, GameObject> _objects = new Dictionary<int, GameObject>();
+	public Dictionary<int, GameObject> _objects = new Dictionary<int, GameObject>();
 
 	public void Add(PlayerInfo info, bool myPlayer = false)
 	{
@@ -27,7 +27,8 @@ public class ObjectManager
 			MyPlayer.SetUserName(info.UserName);
 			//MyPlayer.SyncPos();
 
-			_objects.Add(info.PlayerId, go);
+			if(!(_objects.ContainsKey(info.PlayerId)))
+				_objects.Add(info.PlayerId, go);
 		}
 		else
 		{
@@ -42,7 +43,14 @@ public class ObjectManager
 			iOtherPlayer.SetUserName(info.UserName);
 			//OtherPlayer.SyncPos();
 
-			_objects.Add(info.PlayerId, go);
+			if (!(_objects.ContainsKey(info.PlayerId)))
+				_objects.Add(info.PlayerId, go);
+
+			else
+            {
+				_objects.Remove(info.PlayerId);
+				_objects.Add(info.PlayerId, go);
+			}
 		}
 	}
 


### PR DESCRIPTION
오브젝트 매니저에서 Add(Id) 호출 해줄때 마지막에 딕셔너리에 추가하는 작업 도중 같은 Key 값을 가진 애가 이미 들어가 있는 경우가 있어서 클라이언트 상에서 버그가 나서 제대로 함수가 처리되지 않은 것으로 보임  그래서 일단 딕셔너리 상에 이미 같은 id Key값을 가진 값이 존재하는지 체크하는 방어 코드 추가하는 식으로 처리 함
근본적인 원인은 아마 클라상에서 DeSpawn 패킷이 처리되기 전에 EnterScene패킷이 들어와서 그런 것 아닐까 예상 중인데 더 봐봐야 알 것 같음

일단 내 클라이언트상에서는 에러 없었는데 혹시 모르니 한 번 더 확인해주셈